### PR TITLE
Remove dates from predictions

### DIFF
--- a/bus_stop_prediction.py
+++ b/bus_stop_prediction.py
@@ -28,6 +28,8 @@ def preprocess_stop_data(df: pd.DataFrame, stop_name: str, stop_id: int) -> pd.D
     df_stop["day"] = (df_stop["timestamp"] - df_stop["timestamp"].min()).dt.days
     df_stop["day_of_week"] = df_stop["timestamp"].dt.dayofweek
     df_stop["stop_id"] = stop_id
+    # Store only the time-of-day string to remove the date component
+    df_stop["timestamp"] = df_stop["timestamp"].dt.strftime("%H:%M:%S")
     return df_stop
 
 


### PR DESCRIPTION
## Summary
- store only the time-of-day string in `timestamp` during preprocessing

## Testing
- `python -m py_compile bus_stop_prediction.py`

------
https://chatgpt.com/codex/tasks/task_e_68411b40bbdc83319e9d99155b8699b5