### PR TITLE
Refactor bus stop model to capymoa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # Bus Stop Prediction
 
-Run `python bus_stop_prediction.py` to generate prediction CSV files for each stop.
+Run `python bus_stop_prediction.py` to train a model and generate prediction CSV files for each stop.
+
+The script uses `capymoa`'s `FIMTDD` streaming regressor to fit a model for each
+bus stop. You can provide a local dataset by setting the `BUS_DATASET_PATH`
+environment variable. If not provided, the dataset is downloaded from
+HuggingFace.
 
 Predicted passenger counts are rounded to whole numbers for easier interpretation.
+
+### Requirements
+
+- pandas
+- capymoa
+- torch
+- requests
 


### PR DESCRIPTION
## Summary
- switch prediction script to capymoa's FIMTDD model
- update documentation for capymoa requirements

## Testing
- `python -m py_compile bus_stop_prediction.py`
- `pytest -q` (no tests were collected)
- `python bus_stop_prediction.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68411eb29eb08331a9a8acf5adcd6218